### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang
+
+WORKDIR ${GOPATH}/src/github.com/WinPooh32/peerstohttp/
+
+COPY . .
+RUN go mod vendor -v
+RUN \
+  cd cmd && \
+  go build -mod=vendor -o peerstohttp
+
+ENTRYPOINT [ "cmd/peerstohttp" ]


### PR DESCRIPTION
Add Dockerfile needed to build the code. Useful for enabling Docker development workflows and also helps in addressing﻿ #8.

Uses official `golang` image, latest tag. More info at https://hub.docker.com/_/golang

Almost following build instructions on readme. My main concerns:
* Installing or not the `build-essential` package makes no difference in the built binary.
* Although not needed to build from source, `go get` instruction on readme fails with `no Go files` error. Works when appending `/cmd` to `go get` path.
* I've tried to fetch vendor dependencies to avoid adding them from repo, in order to add dependencies just 'by manifest', but failed. I'm not deep in Go, so I might be missing something. Ideally, modules should not be in the repo but fetched using `go mod` or the like, IMHO.

For convenience, I've set up a public Docker image for testing this PR by means of an Automated Build at https://hub.docker.com/r/pataquets/peerstohttp-src .
You can test it by running:
```
$ docker run --rm -it --net=host pataquets/peerstohttp-src [options...]
```
Using `--net=host` to allow UPnP IGD to work and avoid the need for mapping ports in the container. No files will be saven on the host's filesystem. Use `-v` switches to map dirs from container to host.

Once this is merged, #8 should be a matter of a few clicks to set up on Docker Hub.

Let me know if I can be of any help.
