### PR TITLE
Add -no-tcp flag to disable TCP.

### DIFF
--- a/app/init.go
+++ b/app/init.go
@@ -57,6 +57,7 @@ func p2p(service *settings.Settings, cwd string) (*torrent.Client, error) {
 	// Discovery services.
 	cfg.NoDHT = *service.NoDHT
 	cfg.DisableUTP = *service.NoUTP
+	cfg.DisableTCP = *service.NoTCP
 
 	cfg.DisableIPv4 = *service.NoIPv4
 	cfg.DisableIPv6 = *service.NoIPv6

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -12,6 +12,7 @@ type Settings struct {
 	UploadRate      *int
 	MaxConnections  *int
 	NoDHT           *bool
+	NoTCP           *bool
 	NoUTP           *bool
 	NoIPv4          *bool
 	NoIPv6          *bool
@@ -35,6 +36,7 @@ func (s *Settings) parse() {
 		UploadRate:      flag.Int("up-rate", 0, "upload speed rate in kib/s"),
 		MaxConnections:  flag.Int("max-connections", 50, "max connections per torrent"),
 		NoDHT:           flag.Bool("no-dht", false, "disable dht"),
+		NoTCP:           flag.Bool("no-tcp", false, "disable tcp"),
 		NoUTP:           flag.Bool("no-utp", false, "disable utp"),
 		NoIPv4:          flag.Bool("no-ipv4", false, "disable IPv4"),
 		NoIPv6:          flag.Bool("no-ipv6", false, "disable IPv6"),


### PR DESCRIPTION
To decrease load on consumer-grade ISP routers, it's better to use UDP instead of TCP (that's what uTP does).
I've added a `-no-tcp` flag to force the torrent client to use UDP/uTP.﻿

Tested under Docker with PR submitted in #9.
