### PR TITLE
Docker multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang
+FROM golang:alpine AS build-env
+RUN apk --no-cache add build-base git
 
 WORKDIR ${GOPATH}/src/github.com/WinPooh32/peerstohttp/
 
@@ -6,6 +7,12 @@ COPY . .
 RUN go mod vendor -v
 RUN \
   cd cmd && \
-  go build -mod=vendor -o peerstohttp
+  go build -mod=vendor -o /peerstohttp
 
-ENTRYPOINT [ "cmd/peerstohttp" ]
+
+FROM alpine
+WORKDIR /app
+RUN apk add --no-cache libstdc++ libgcc
+COPY --from=build-env /peerstohttp /app/peerstohttp
+
+ENTRYPOINT [ "./peerstohttp" ]


### PR DESCRIPTION
multi-stage docker builds helps make tiny images.
based on golang:alpine image.
the final image size is ~30M