### PR TITLE
Add Docker image publish Github Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,5 @@
 name: Publish Docker image
 
-env:
-  DOCKERHUB_IMAGE: peerstohttp
-
 on: push
 
 jobs:
@@ -11,6 +8,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       # Required if building multi-arch images
       - name: Set up QEMU
@@ -34,4 +43,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/386
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,37 @@
+name: Publish Docker image
+
+env:
+  DOCKERHUB_IMAGE: peerstohttp
+
+on: push
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Required if building multi-arch images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - id: buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/386
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR ${GOPATH}/src/github.com/WinPooh32/peerstohttp/
 COPY . .
 RUN \
     cd cmd && \
-    go build -mod=vendor -o /peerstohttp
+    go build -v -mod=vendor -o /peerstohttp
 
 
 FROM alpine


### PR DESCRIPTION
Github Action requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (generated from hub.docker.com) to be set in the Github secrets section in the repo config.
Pushes trigger Github Action to build Docker images and push them to Docker Hub:
* Git branch `branchname` pushes `peerstohttp:branchname` image tag. Thus, `peerstohttp:master` acts as an edge/unreleased/HEAD image tag. Other branches push to their respective image tags (useful for testing feature branches),
* Git tags `vX.Y.X` push to `peerstohttp:X.Y.Z`, `peerstohttp:X.Y`, `peerstohttp:X` and `peerstohttp:latest`.`:latest` tag is the default if no tag specified, so `docker pull peerstohttp` pulls latest released (stable) git tag.

Also:
* Added verbosity during build, to have more troubleshooting info in the actions.
* Enabled Dependabot (only for Github Actions manifests). No need to toggle or configure anything.

EDIT:
Check out [action runs](https://github.com/pataquets/peerstohttp/actions) and [image tags](https://hub.docker.com/repository/docker/pataquets/peerstohttp/tags) from my testing on my repos.