### PR TITLE
Fix: service was ignoring the `-torrDebug` switch.

### DIFF
--- a/app/init.go
+++ b/app/init.go
@@ -88,7 +88,7 @@ func p2p(service *settings.Settings, cwd string) (*torrent.Client, error) {
 	}
 
 	// Torrent debug.
-	cfg.Debug = false
+	cfg.Debug = *service.TorrentDebug
 
 	if !*service.TorrentDebug {
 		cfg.Logger = anacrolixlog.Discard


### PR DESCRIPTION
When enabling the `-torrDebug` switch, nothing different was happening.
Digging a bit, I've found that the `cfg.Debug` service variable, was being set always to `false`, no matter what was requested via switches.

EDIT: Isn't there any way to speed up compilations (under Docker) if only app code changes? (no deps nor libs).