### PR TITLE
Delegate magnet URI handling to torrent.AddMagnet instead of processing TorrentSpec.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -159,13 +159,8 @@ func (app *App) TrackMagnetContext(ctx context.Context, magnet *metainfo.Magnet)
 	var err error
 	var t *torrent.Torrent
 
-	var spec = &torrent.TorrentSpec{
-		Trackers:    [][]string{magnet.Trackers},
-		DisplayName: magnet.DisplayName,
-		InfoHash:    magnet.InfoHash,
-	}
 
-	t, _, err = app.client.AddTorrentSpec(spec)
+	t, err = app.client.AddMagnet(magnet.String())
 	if err != nil {
 		return nil, fmt.Errorf("torrent add magnet: %w", err)
 	}


### PR DESCRIPTION
Instead of converting metainfo into TorrentSpec for no gain, just pass the magnet URI directly to torrent.AddMagnet() to do the whole processing. If the spec changes later, current code should track new object members to avoid leaving any behind (as already happens).

### Steps to reproduce an existing problem
Currently, passing the [BEP9](https://www.bittorrent.org/beps/bep_0009.html#magnet-uri-format) `x.pe` magnet URI query param is not working/ignored. You can see this better with rarely found torrents, poorly known in trackers and DHTs. The rarest the torrent, the better to reproduce.
* Set up or find a Torrent server with a known IP (192.168.1.100 on port 51413 in this example), seeding some rare torrent.
* Run `peerstohttp -no-dht -torrDebug` (#21 required for `-torrDebug` to work), preventing peer discovery via DHT.
* Add any known torrent from above, with a minimal magnet URI, with no trackers, just `x.pe`. Example: http://localhost/list/html/-/-/magnet/magnet:?xt=urn:btih:TORRENTHASH&x.pe=192.168.1.100:51413
* Since the service won't be able to download the torrent metadata from neither trackers/DHT, nor other peers and *our known seed peer* passed via `x.pe` *is ignored*, the request will stall.

Now try again with current PR branch. You'll see the torrent debug messages adding the provided peer IP and the server contacting it to instantly download the metadata info, fullfilling the request.