### PR TITLE
Allow disabling UPnP port forwarding (`-no-upnp`).

### DIFF
--- a/app/init.go
+++ b/app/init.go
@@ -65,6 +65,8 @@ func p2p(service *settings.Settings, cwd string) (*torrent.Client, error) {
 	cfg.DisableIPv4 = *service.NoIPv4
 	cfg.DisableIPv6 = *service.NoIPv6
 
+	cfg.NoDefaultPortForwarding = *service.NoUPnP
+
 	if *service.ProxyHTTP != "" {
 		var u, err = url.Parse(*service.ProxyHTTP)
 		if err != nil {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -13,6 +13,7 @@ type Settings struct {
 	MaxConnections  *int
 	CacheCapacity   *int64
 	NoDHT           *bool
+	NoUPnP          *bool
 	NoTCP           *bool
 	NoUTP           *bool
 	NoIPv4          *bool
@@ -37,6 +38,7 @@ func (s *Settings) parse() {
 		UploadRate:      flag.Int("up-rate", 0, "upload speed rate in kib/s"),
 		MaxConnections:  flag.Int("max-connections", 50, "max connections per torrent"),
 		NoDHT:           flag.Bool("no-dht", false, "disable dht"),
+		NoUPnP:          flag.Bool("no-upnp", false, "disable UPnP port forwarding"),
 		NoTCP:           flag.Bool("no-tcp", false, "disable tcp"),
 		NoUTP:           flag.Bool("no-utp", false, "disable utp"),
 		NoIPv4:          flag.Bool("no-ipv4", false, "disable IPv4"),


### PR DESCRIPTION
A must in hosting environments where LAN-style broadcasts are not appreciated by net admins.